### PR TITLE
Added permissions in CircleCI configs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,5 +18,7 @@ dependencies:
 
 test:
   override:
+    # Give permissions
+    - chmod +x gradlew
     - ./gradlew assembleDebug -PdisablePreDex:
         timeout: 1800


### PR DESCRIPTION
Added permissions for CircleCI to properly execute the command ./gradlew assembleDebug which will build the app and run the local unit tests.