### PR TITLE
New Unit tests for Multiple Queues

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/fragment/QueuesFragment.java
+++ b/app/src/main/java/de/danoeh/antennapod/fragment/QueuesFragment.java
@@ -79,6 +79,7 @@ public class QueuesFragment extends Fragment {
 
     // List of feed items
     private List<FeedItem> feedItems;
+
     //Object where we will store the list of queues, important for context menu
     private static ArrayList<Queue> queueList = new ArrayList<>();
 
@@ -234,21 +235,24 @@ public class QueuesFragment extends Fragment {
         }
     }
 
-    private void removeId(long Id){
-
+    public void removeId(long Id){
 
         queueList = loadList(this.getActivity(), queueList);
 
         if (queueList == null) {
             queueList = new ArrayList<>();
         }
+        removeQueue(Id);
+        storeList(this.getActivity(), queueList);
+    }
+
+    public void removeQueue(long Id){
         for (Queue queues : queueList) {
             if (queues.getName().equalsIgnoreCase(this.queue.getName())) {
                 queues.getEpisodesIDList().remove(Id);
                 queue.getEpisodesIDList().remove(Id);
             }
         }
-        storeList(this.getActivity(), queueList);
     }
 
 
@@ -353,4 +357,15 @@ public class QueuesFragment extends Fragment {
 
     };
 
+    public void setEpisodesAdapter(EpisodesAdapter episodesAdapter) {
+        this.episodesAdapter = episodesAdapter;
+    }
+
+    public void setQueueList(ArrayList<Queue> queueList){
+        this.queueList = queueList;
+    }
+
+    public ArrayList<Queue> getQueueList() {
+        return this.queueList;
+    }
 }

--- a/app/src/test/java/multipleQueueTests/QueueFragmentTest.java
+++ b/app/src/test/java/multipleQueueTests/QueueFragmentTest.java
@@ -1,0 +1,69 @@
+package multipleQueueTests;
+
+/**
+ * Created by James on 2018-04-17.
+ */
+
+import static org.mockito.Mockito.*;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.danoeh.antennapod.core.feed.Queue;
+import de.danoeh.antennapod.fragment.QueuesFragment;
+import de.danoeh.antennapod.adapter.EpisodesAdapter;
+
+import static junit.framework.Assert.assertEquals;
+
+public class QueueFragmentTest {
+
+    //class to be tested
+    private QueuesFragment queuesFragment;
+    //dependency
+    private EpisodesAdapter mockEpisodesAdapter;
+
+
+
+
+    @Before
+    public void beforeTests(){
+        MockitoAnnotations.initMocks(this);
+
+        //Our fragment to be tested
+        queuesFragment = new QueuesFragment();
+
+        //Mocking dependencies
+        mockEpisodesAdapter = mock(EpisodesAdapter.class);
+        queuesFragment.setEpisodesAdapter(mockEpisodesAdapter);
+
+    }
+
+    @Test
+    public void testRemoveEpisode(){
+        Queue testQueue = new Queue("test");
+        List<Long> episodeIdList = new ArrayList<>();
+        ArrayList<Queue> queuesList = new ArrayList<>();
+        episodeIdList.add((long) 1);
+        episodeIdList.add((long) 2);
+        testQueue.setEpisodesIDList(episodeIdList);
+        queuesList.add(testQueue);
+        queuesFragment.setQueue(testQueue);
+        queuesFragment.setQueueList(queuesList);
+        Long tester = (long) 2;
+        Long tester2 = (long) 1;
+
+        assertEquals(queuesFragment.getQueueList().get(0).equals(testQueue), true);
+        assertEquals(queuesFragment.getQueue().getEpisodesIDList().get(0), tester2);
+        assertEquals(queuesFragment.getQueueList().get(0).getEpisodesIDList().get(0), tester2);
+        queuesFragment.removeQueue((long)1);
+        assertEquals(queuesFragment.getQueue().getEpisodesIDList().get(0), tester);
+        assertEquals(queuesFragment.getQueueList().get(0).getEpisodesIDList().get(0), tester);
+
+    }
+
+
+}

--- a/app/src/test/java/multipleQueueTests/QueueListFragmentTest.java
+++ b/app/src/test/java/multipleQueueTests/QueueListFragmentTest.java
@@ -59,4 +59,15 @@ public class QueueListFragmentTest {
         verify(mockQueueAdapter, times(2)).updateQueueList(qlFragment.getQueuesList());
         assertEquals(1, qlFragment.getQueuesList().size());
     }
+
+    @Test
+    public void testRenameQueue(){
+        qlFragment.createNewQueue("Queue 1");
+        qlFragment.createNewQueue("Queue 2");
+        assertEquals("Queue 1", qlFragment.getQueuesList().get(0).getName());
+        Queue testQueue = new Queue("test");
+        qlFragment.renameWithPos(0, testQueue);
+        assertEquals("test", qlFragment.getQueuesList().get(0).getName());
+    }
+
 }


### PR DESCRIPTION
Issues #115 , #40 

Added unit test for rename queues, and for remove an episode from the queue